### PR TITLE
DONTCARE string to bypass unnecessary extractions. This is mainly use…

### DIFF
--- a/src/main/java/com/quantxt/types/DictItm.java
+++ b/src/main/java/com/quantxt/types/DictItm.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 public class DictItm implements Serializable {
     private static final long serialVersionUID = -1878032088113144067L;
+    public static String DONT_CARE = "__DONTCARE__";
 
     private String category;
     private List<String> phraseList;


### PR DESCRIPTION
…d in doc-analytics library and may need to be moved there